### PR TITLE
added shm-size param

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -305,7 +305,8 @@ fi
 
 # Support docker run --gpus
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_GPUS:-}" ]] ; then
-  args+=("--gpus" "${BUILDKITE_PLUGIN_DOCKER_GPUS:-}")
+  args+=("--gpus" "${BUILDKITE_PLUGIN_DOCKER_GPUS:-}"
+  args+=("--shm-size 8G")
 fi
 
 # Support docker run --runtime


### PR DESCRIPTION
added arg to docker run in order to use num_workers > 0 in pytorch Dataloader. Solution from https://github.com/pytorch/pytorch/issues/5040