### PR TITLE
Optionally keep containers

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -95,8 +95,6 @@ else
   args+=("-i")
 fi
 
-args+=("--rm")
-
 # Support docker run --init.
 if [[ "${BUILDKITE_PLUGIN_DOCKER_INIT:-$init_default}" =~ ^(true|on|1)$ ]] ; then
     args+=("--init")
@@ -296,6 +294,11 @@ fi
 # Support docker run --cap-add
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_CAP_ADD:-}" ]] ; then
   args+=("--cap-add" "${BUILDKITE_PLUGIN_DOCKER_CAP_ADD:-}")
+fi
+
+# Support docker run --rm
+if [[ -z "${BUILDKITE_PLUGIN_DOCKER_KEEP_CONTAINER:-}" ]] ; then
+  args+=("--rm")
 fi
 
 # Support docker run --pid


### PR DESCRIPTION
If `BUILDKITE_PLUGIN_DOCKER_KEEP_CONTAINER` is different from empty/null, the arg `--rm` won't be appended to the arguments so the container won't be removed after terminating. This is really useful when you want to debug e.g. a failing test. 